### PR TITLE
On-demand (tickless) cleanup

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,7 +50,8 @@ type Config struct {
 	// AllowedOrigins specifies Access-Control-Allow-Origin header.
 	AllowedOrigins string `yaml:"allowed_origins"`
 
-	// Internal, used only for testing. Always 60 secs in production.
+	// Minimal interval between cleanups. Always 60 secs in production.
+	// Internal, used only for testing.
 	CleanupIntervalSecs int `yaml:"-"`
 }
 

--- a/db.go
+++ b/db.go
@@ -49,6 +49,7 @@ func openDB(driver, dsn string) (*db, error) {
 		db.Exec(`SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE`)
 	}
 	if driver == "sqlite3" {
+		db.DB.SetMaxOpenConns(1)
 		// Also some optimizations for SQLite to make it FAA-A-A-AST.
 		db.Exec(`PRAGMA auto_vacuum = INCREMENTAL`)
 		db.Exec(`PRAGMA journal_mode = WAL`)

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	google.golang.org/appengine v1.2.0 // indirect
 	gopkg.in/yaml.v2 v2.2.1
 )
+
+go 1.11

--- a/server_test.go
+++ b/server_test.go
@@ -327,6 +327,7 @@ func TestCleanup(t *testing.T) {
 	splittenURL := strings.Split(URL, "/")
 	UUID := splittenURL[len(splittenURL)-1]
 	time.Sleep(4 * time.Second)
+	c.Get(URL) // Trigger cleanup
 
 	_, err := os.Stat(filepath.Join(serv.Conf.StorageDir, UUID))
 	if err == nil || !os.IsNotExist(err) {


### PR DESCRIPTION
Track last run of cleanupFiles and use it to communicate if the cleanup is in progress and whether we must run it yet, making cleanup process tickless. The application does nothing on idle, which is healthy!